### PR TITLE
Fix: cp test.rb tttttt => 500 Internal Server Error

### DIFF
--- a/lib/dav4rack/file_resource.rb
+++ b/lib/dav4rack/file_resource.rb
@@ -109,7 +109,7 @@ module DAV4Rack
     # HTTP COPY request.
     #
     # Copy this resource to given destination resource.
-    def copy(dest)
+    def copy(dest, overwrite = false)
       if stat.directory?
         dest.make_collection
       else


### PR DESCRIPTION
cp test.rb tttttt => 500 Internal Server Error

127.0.0.1 - - [25/Oct/2010 08:56:11] "PROPFIND /tttttt/ HTTP/1.1" 404 - 0.0030
ArgumentError: wrong number of arguments (2 for 1)
    /usr/local/lib/ruby/gems/1.9.1/gems/dav4rack-0.1.3/lib/dav4rack/file_resource.rb:112:in `copy'
    /usr/local/lib/ruby/gems/1.9.1/gems/dav4rack-0.1.3/lib/dav4rack/resource.rb:107:in`method_missing'
    /usr/local/lib/ruby/gems/1.9.1/gems/dav4rack-0.1.3/lib/dav4rack/controller.rb:122:in `move'
    /usr/local/lib/ruby/gems/1.9.1/gems/dav4rack-0.1.3/lib/dav4rack/controller.rb:106:in`copy'
    /usr/local/lib/ruby/gems/1.9.1/gems/dav4rack-0.1.3/lib/dav4rack/handler.rb:26:in `call'
    /usr/local/lib/ruby/gems/1.9.1/gems/rack-1.2.1/lib/rack/lint.rb:48:in`_call'
    /usr/local/lib/ruby/gems/1.9.1/gems/rack-1.2.1/lib/rack/lint.rb:36:in `call'
    /usr/local/lib/ruby/gems/1.9.1/gems/rack-1.2.1/lib/rack/reloader.rb:44:in`call'
    /usr/local/lib/ruby/gems/1.9.1/gems/rack-1.2.1/lib/rack/commonlogger.rb:18:in `call'
    /usr/local/lib/ruby/gems/1.9.1/gems/rack-1.2.1/lib/rack/showexceptions.rb:24:in`call'
    /usr/local/lib/ruby/gems/1.9.1/gems/rack-1.2.1/lib/rack/content_length.rb:13:in `call'
    /usr/local/lib/ruby/gems/1.9.1/gems/rack-1.2.1/lib/rack/chunked.rb:15:in`call'
    /usr/local/lib/ruby/gems/1.9.1/gems/rack-1.2.1/lib/rack/handler/mongrel.rb:67:in `process'
    /usr/local/lib/ruby/gems/1.9.1/gems/mongrel-1.2.0.pre2/lib/mongrel.rb:165:in`block in process_client'
    /usr/local/lib/ruby/gems/1.9.1/gems/mongrel-1.2.0.pre2/lib/mongrel.rb:164:in `each'
    /usr/local/lib/ruby/gems/1.9.1/gems/mongrel-1.2.0.pre2/lib/mongrel.rb:164:in`process_client'
    /usr/local/lib/ruby/gems/1.9.1/gems/mongrel-1.2.0.pre2/lib/mongrel.rb:291:in `block (2 levels) in run'
