### PR TITLE
Running dav4rack on port other than 80

### DIFF
--- a/lib/dav4rack/controller.rb
+++ b/lib/dav4rack/controller.rb
@@ -114,7 +114,7 @@ module DAV4Rack
       resource.lock_check unless args.include?(:copy)
       destination = url_unescape(env['HTTP_DESTINATION'].sub(%r{https?://([^/]+)}, ''))
       dest_host = $1
-      raise BadGateway if dest_host and dest_host != request.host
+      raise BadGateway if dest_host and dest_host.gsub(/:\d{2,4}$/,'') != request.host
       raise Forbidden if destination == resource.public_path
       dest = resource_class.new(destination, clean_path(destination), @request, @response, @options.merge(:user => resource.user))
       status = nil


### PR DESCRIPTION
This commit allows for the port number when checking the copy/move destination in the event we are using something other than 80 to host the webdav.  Although you wouldn't want to do something like this in production, its something that tripped me up when just testing on port 3000.
