### PR TITLE
Use #httpdate instead of #xmlschema for creation date

### DIFF
--- a/lib/dav4rack/resource.rb
+++ b/lib/dav4rack/resource.rb
@@ -347,7 +347,7 @@ module DAV4Rack
       case name
       when 'resourcetype'     then resource_type
       when 'displayname'      then display_name
-      when 'creationdate'     then creation_date.xmlschema 
+      when 'creationdate'     then creation_date.httpdate 
       when 'getcontentlength' then content_length.to_s
       when 'getcontenttype'   then content_type
       when 'getetag'          then etag


### PR DESCRIPTION
The WebDAV Mini-Redirector used when creating new MS Office files outright fails when `#xmlschema` is used for the creation or modification date.

Changing this to use `#httpdate` like getlastmodified does seems to take, and the WebDAV clients I can get my hands on (Windows, Mac and iPad) seem to work with it just fine.
