### PR TITLE
Remove pretty XML formatting (fixes Mini-Redirector)

### DIFF
--- a/lib/dav4rack/controller.rb
+++ b/lib/dav4rack/controller.rb
@@ -413,7 +413,7 @@ module DAV4Rack
         end
       end
       
-      response.body = doc.to_xml
+      response.body = doc.to_xml(:save_with => Nokogiri::XML::Node::SaveOptions::AS_XML)
       response["Content-Type"] = 'text/xml; charset="utf-8"'
       response["Content-Length"] = response.body.size.to_s
     end


### PR DESCRIPTION
It may be nice when debugging to show formatted (indented) XML, but against DAV4Rack master, this was the only thing keeping Windows XP from being able to map a drive.

I can't attempt to explain why they would use such a fragile parser, but after combing over the responses of dav4rack versus other DAV servers that worked with the Mini-Redirector in Windows XP, this is what it came down to. (And only after telling myself "surely, Microsoft wouldn't do something that terrible...")

Windows XP Mini-Redirector chokes when the XML is formatted with new-lines and spaces. This asks Nokogiri to not do that.

Tested against Windows XP and Windows 7 built-in WebDAV, Mac OSX 10.7 built-in WebDAV, and as many clients I could get my hands on.
