### PR TITLE
Allow xml_base to include other XML attribtutes on the root node.

### DIFF
--- a/lib/dav4rack/controller.rb
+++ b/lib/dav4rack/controller.rb
@@ -403,10 +403,10 @@ module DAV4Rack
 
     # root_type:: Root tag name
     # Render XML and set Rack::Response#body= to final XML
-    def render_xml(root_type)
+    def render_xml(root_type, root_attribs = {})
       raise ArgumentError.new 'Expecting block' unless block_given?
       doc = Nokogiri::XML::Builder.new do |xml_base|
-        xml_base.send(root_type.to_s, 'xmlns:D' => 'DAV:') do
+        xml_base.send(root_type.to_s, {'xmlns:D' => 'DAV:'}.merge(root_attribs)) do
           xml_base.parent.namespace = xml_base.parent.namespace_definitions.first
           xml = xml_base['D']
           yield xml


### PR DESCRIPTION
This is potentially useful for things like CardDAV that mix in their own namespace in the response.
