### PR TITLE
Look for the DAV: namespace (it may not be the first), and allow resolving other namespaces.

### DIFF
--- a/lib/dav4rack/controller.rb
+++ b/lib/dav4rack/controller.rb
@@ -385,10 +385,11 @@ module DAV4Rack
 
     # Namespace being used within XML document
     # TODO: Make this better
-    def ns
+    def ns(wanted_uri="DAV:")
       _ns = ''
       if(request_document && request_document.root && request_document.root.namespace_definitions.size > 0)
-        _ns = request_document.root.namespace_definitions.first.prefix.to_s
+        _ns = request_document.root.namespace_definitions.collect{|__ns| __ns if __ns.href == wanted_uri}.compact.first.prefix.to_s
+        _ns = request_document.root.namespace_definitions.first.prefix.to_s if _ns.empty?
         _ns += ':' unless _ns.empty?
       end
       _ns


### PR DESCRIPTION
Apple's AddressBook.app sends out XML like this:

```
<?xml version="1.0" encoding="utf-8"?>
  <x0:propfind xmlns:x1="http://calendarserver.org/ns/" xmlns:x0="DAV:" xmlns:x3="http://apple.com/ns/ical/" xmlns:x2="urn:ietf:params:xml:ns:caldav">
    <x0:prop><x1:getctag/></x0:prop>
  </x0:propfind>
```

Which doesn't match the xpath query for a propfind as x0 isn't DAV:.  This pulls the first DAV: namespace.
