### PR TITLE
PROPSTAT flexibility

### DIFF
--- a/lib/dav4rack/controller.rb
+++ b/lib/dav4rack/controller.rb
@@ -488,7 +488,9 @@ module DAV4Rack
         xml.propstat do
           xml.prop do
             for name, value in props
-              if(value.is_a?(Nokogiri::XML::Node))
+              if(value.is_a?(Nokogiri::XML::DocumentFragment))
+                xml.__send__ :insert, value
+              elsif(value.is_a?(Nokogiri::XML::Node))
                 xml.send(name) do
                   xml_convert(xml, value)
                 end

--- a/lib/dav4rack/controller.rb
+++ b/lib/dav4rack/controller.rb
@@ -175,7 +175,11 @@ module DAV4Rack
         multistatus do |xml|
           find_resources.each do |resource|
             xml.response do
-              xml.href "#{scheme}://#{host}:#{port}#{url_escape(resource.public_path)}"
+              if resource.fully_qualified
+                xml.href "#{scheme}://#{host}:#{port}#{url_escape(resource.public_path)}"
+              else
+                xml.href url_escape(resource.public_path)
+              end
               propstats(xml, get_properties(resource, names))
             end
           end

--- a/lib/dav4rack/resource.rb
+++ b/lib/dav4rack/resource.rb
@@ -16,7 +16,7 @@ module DAV4Rack
   end
   
   class Resource
-    attr_reader :path, :options, :public_path, :request, :response
+    attr_reader :path, :options, :public_path, :request, :response, :fully_qualified
     attr_accessor :user
     @@blocks = {}
     
@@ -71,6 +71,7 @@ module DAV4Rack
       ]
       @public_path = public_path.dup
       @path = path.dup
+      @fully_qualified = true # Do we want the whole URL or just the path in PROPFIND responses
       @request = request
       @response = response
       unless(options.has_key?(:lock_class))


### PR DESCRIPTION
These commits add two potentially useful features:
- Allow insertion of XML via DocumentFragment objects (allowing one to be a bit more elegant and specify namespaces at the 'root' node)
- Allow PROPSTAT to return paths instead of fully qualified URLs.  Apple's AddressBook.app treats all the hrefs as paths, meaning http://foo.com/bar turns into /http://foo.com/bar with obvious borkage.
