### PR TITLE
Allow routes to specify an alternate controller class.

### DIFF
--- a/lib/dav4rack/handler.rb
+++ b/lib/dav4rack/handler.rb
@@ -24,7 +24,8 @@ module DAV4Rack
         
         controller = nil
         begin
-          controller = Controller.new(request, response, @options.dup)
+          controller_class = @options[:controller_class] || Controller
+          controller = controller_class.new(request, response, @options.dup)
           controller.authenticate
           res = controller.send(request.request_method.downcase)
           response.status = res.code if res.respond_to?(:code)


### PR DESCRIPTION
Brings this more in line with traditional Rails routes.  Also useful for implementing additional verbs like REPORT.
