### PR TITLE
Clean up the parent resource code.

### DIFF
--- a/lib/dav4rack/resource.rb
+++ b/lib/dav4rack/resource.rb
@@ -391,9 +391,9 @@ module DAV4Rack
     
     # Return parent of this resource
     def parent
-      elements = @path.scan(/[^\/]+/)
-      return nil if elements.empty?
-      self.class.new(('/' + @public_path.scan(/[^\/]+/)[0..-2].join('/')), ('/' + elements[0..-2].to_a.join('/')), @request, @response, @options.merge(:user => @user))
+      return nil if @path.empty?
+      parent_path = File.split(@public_path).first
+      self.class.new(parent_path, parent_path, @request, @response, @options.merge(:user => @user))
     end
     
     # Return list of descendants


### PR DESCRIPTION
- String#scan will only return an empty array if string is empty
- Use File#split not String#scan + regexps + negative array indexes because the former's intent is more self-evident
