### PR TITLE
small fix to propfind

### DIFF
--- a/lib/dav4rack/controller.rb
+++ b/lib/dav4rack/controller.rb
@@ -178,7 +178,8 @@ module DAV4Rack
           ).xpath(
             "//#{ns}propfind/#{ns}prop"
           ).children.find_all{ |item|
-            item.element? && item.name.start_with?(ns)
+            # With nokogiri 1.5.5 it appears that the namespace prefix is already stripped
+            item.element?# && item.name.start_with?(ns)
           }.map{ |item|
             item.name.sub("#{ns}::", '')
           }

--- a/lib/dav4rack/controller.rb
+++ b/lib/dav4rack/controller.rb
@@ -301,6 +301,20 @@ module DAV4Rack
       raise Unauthorized unless authed
     end
     
+    # If the resource class defines a `prepare` method, it is called.
+    # This happens between authentication and request-processing and
+    # can be used to check and personalise the filing system.
+    #
+    # It is quite possible that I am not making the right use of the 
+    # _DAV_ prefix here.
+    #
+    def prepare
+      if resource.respond_to?(:_DAV_prepare, true)
+        resource.send :_DAV_prepare
+      end
+    end
+    
+    
     # ************************************************************
     # private methods
     

--- a/lib/dav4rack/handler.rb
+++ b/lib/dav4rack/handler.rb
@@ -27,6 +27,7 @@ module DAV4Rack
           controller_class = @options[:controller_class] || Controller
           controller = controller_class.new(request, response, @options.dup)
           controller.authenticate
+          controller.prepare
           res = controller.send(request.request_method.downcase)
           response.status = res.code if res.respond_to?(:code)
         rescue HTTPStatus::Unauthorized => status
@@ -49,7 +50,7 @@ module DAV4Rack
         buf = true
         buf = request.body.read(8192) while buf
 
-        Logger.debug "Response in string form. Outputting contents: \n#{response.body}" if response.body.is_a?(String)
+        Logger.debug "Response in stringish form. Outputting contents: \n#{response.body}" if response.body.is_a?(String)
         Logger.info "Completed in: #{((Time.now.to_f - start.to_f) * 1000).to_i} ms | #{response.status} [#{request.url}]"
         
         response.body.is_a?(Rack::File) ? response.body.call(env) : response.finish


### PR DESCRIPTION
I'm finding that when Nokogiri (v1.5.5) parses the request_document it returns the names of child nodes with the namespace prefix already removed. Specifically, with this request_document (from goodreader):

``` xml
<D:propfind xmlns:D="DAV:">
    <D:prop>
        <D:getlastmodified/>
        <D:getcontentlength/>
        <D:resourcetype/>
    </D:prop>
</D:propfind>
```

The returned names of the child nodes of `<D:prop>` are just 'getlastmodified', 'getcontentlength' and 'resourcetype', and are therefore ignored when the following find_all operation tests for the prefix. Perhaps there are more complex cases where the prop node has other children? But in my case If I remove that test everything works very nicely, including folder sync. 

Thank you for the library: it has just saved me a lot of time when I needed it most.
