### PR TITLE
allow changing Dav header

### DIFF
--- a/lib/dav4rack/controller.rb
+++ b/lib/dav4rack/controller.rb
@@ -18,7 +18,15 @@ module DAV4Rack
       @request = request
       @response = response
       @options = options
+      
+      @dav_extensions = options.delete(:dav_extensions) || []
+      @alway_include_dav_header = options.delete(:alway_include_dav_header)
+      
       @resource = resource_class.new(actual_path, implied_path, @request, @response, @options)
+      
+      if @alway_include_dav_header
+        add_dav_header()
+      end
     end
     
     # s:: string
@@ -35,12 +43,19 @@ module DAV4Rack
     # Unescape URL string
     def url_unescape(s)
       URI.unescape(s)
-    end  
+    end
+    
+    def add_dav_header
+      unless response["Dav"]
+        dav_support = ["1", "2"] + @dav_extensions
+        response["Dav"] = dav_support.join(', ')
+      end
+    end
     
     # Return response to OPTIONS
     def options
+      add_dav_header()
       response["Allow"] = 'OPTIONS,HEAD,GET,PUT,POST,DELETE,PROPFIND,PROPPATCH,MKCOL,COPY,MOVE,LOCK,UNLOCK'
-      response["Dav"] = "1, 2"
       response["Ms-Author-Via"] = "DAV"
       OK
     end


### PR DESCRIPTION
:alway_include_dav_header is here because some carddav clients can remove a roundtrip if proper support is advertised on first response (PROPFIND).

and : dav_extensions allows to add the proper carddav support without having to subclass (I still need to subclass for now but I hope I will find a clean way to avoid that)
