### PR TITLE
Add ability to build xml from within a resource

### DIFF
--- a/lib/dav4rack/controller.rb
+++ b/lib/dav4rack/controller.rb
@@ -441,15 +441,8 @@ module DAV4Rack
     
     # root_type:: Root tag name
     # Render XML and set Rack::Response#body= to final XML
-    def render_xml(root_type)
-      raise ArgumentError.new 'Expecting block' unless block_given?
-      doc = Nokogiri::XML::Builder.new do |xml_base|
-        xml_base.send(root_type.to_s, {'xmlns:D' => 'DAV:'}.merge(resource.root_xml_attributes)) do
-          xml_base.parent.namespace = xml_base.parent.namespace_definitions.first
-          xml = xml_base['D']
-          yield xml
-        end
-      end
+    def render_xml(*args, &block)
+      doc = resource.build_xml(*args, &block)
      
       if(@options[:pretty_xml])
         response.body = doc.to_xml

--- a/lib/dav4rack/resource.rb
+++ b/lib/dav4rack/resource.rb
@@ -465,6 +465,23 @@ module DAV4Rack
         (request.respond_to?(:user_agent) ? request.user_agent : request.env['HTTP_USER_AGENT']).to_s =~ regexp
       end
     end
+
+    def build_xml(root_type, ns = 'D')
+      raise ArgumentError.new 'Expecting block' unless block_given?
+      builder = Nokogiri::XML::Builder.new do |xml|
+        xml.send(root_type.to_s, {'xmlns:D' => 'DAV:'}.merge(@root_xml_attributes)) do
+          xml.parent.namespace = xml.parent.namespace_definitions.find do |n|
+            n.prefix == ns
+          end
+          yield xml[ns]
+        end
+      end
+    end
+
+    def xml_frag(*args, &block)
+      builder = build_xml(*args, &block)
+      builder.doc.root
+    end
    
     protected
 


### PR DESCRIPTION
I think it would be useful to be able to return xml from the get_property methods and this makes that task simpler:

``` ruby
def resource_type
  xml_frag(:resourcetype) do |xml|
    xml.collection
    xml['card'].addressbook
  end
end
```

A better option may be to pass the xml document directly to each get_property method (i.e. resource_type) so that they can edit the doc directly, but that would involve a much larger rewrite of the controller/resource that I'm not sure if you would be interested in.
