### PR TITLE
Small fix for DAV4Rack::File - 0.3.0-dev

### DIFF
--- a/lib/dav4rack/file.rb
+++ b/lib/dav4rack/file.rb
@@ -17,7 +17,7 @@ module DAV4Rack
     def _call(env)
       begin
         if F.file?(@path) && F.readable?(@path)
-          serving
+          serving(env)
         else
           raise Errno::EPERM
         end


### PR DESCRIPTION
I had a some issues when trying to include `DAV4Rack::File` in my resource.
- `#serving` in `Rack::File` class now need `env` as a param
- And there is a name conflict for `File` in the `FileResource` methods
