### PR TITLE
FileResourceLock#unlock_token nil root path and variable not defined

### DIFF
--- a/lib/dav4rack/file_resource_lock.rb
+++ b/lib/dav4rack/file_resource_lock.rb
@@ -43,8 +43,17 @@ module DAV4Rack
         struct = store.transaction(true){
           store[:tokens][token]
         }
-        if(tok)
-          self.class.new(:path => struct[:path], :root => croot)
+
+        # MS Word patch # MS remove first and last char of tokens
+        if !struct
+          struct = store.transaction(true){
+            store[:tokens].keys.each {|k| token = k if k.include?(token) }
+            store[:tokens][token]
+          }
+        end
+
+        if(struct)
+          self.new(:path => struct[:path], :root => croot)
         else
           nil
         end
@@ -109,9 +118,9 @@ module DAV4Rack
 
     def save
       struct = {
-        :path => path, 
-        :token => token, 
-        :timeout => timeout, 
+        :path => path,
+        :token => token,
+        :timeout => timeout,
         :depth => depth,
         :created_at => Time.now,
         :owner => owner

--- a/lib/dav4rack/file_resource_lock.rb
+++ b/lib/dav4rack/file_resource_lock.rb
@@ -77,8 +77,8 @@ module DAV4Rack
       end
 
       def init_pstore(croot)
-        path = File.join(croot, '.attribs', 'locks.pstore')
-        FileUtils.mkdir_p(File.dirname(path)) unless File.directory?(File.dirname(path))
+        path = ::File.join(croot, '.attribs', 'locks.pstore')
+        FileUtils.mkdir_p(::File.dirname(path)) unless ::File.directory?(::File.dirname(path))
         store = IS_18 ? PStore.new(path) : PStore.new(path, true)
         store.transaction do
           unless(store[:paths])

--- a/lib/dav4rack/resource.rb
+++ b/lib/dav4rack/resource.rb
@@ -342,7 +342,7 @@ module DAV4Rack
 
     # Name of the resource
     def name
-      File.basename(path)
+      ::File.basename(path)
     end
 
     # Name of the resource to be displayed to the client
@@ -410,8 +410,8 @@ module DAV4Rack
     def parent
       unless(@path.to_s.empty?)
         self.class.new(
-          File.split(@public_path).first,
-          File.split(@path).first,
+          ::File.split(@public_path).first,
+          ::File.split(@path).first,
           @request,
           @response,
           @options.merge(

--- a/lib/dav4rack/resources/file_resource.rb
+++ b/lib/dav4rack/resources/file_resource.rb
@@ -259,8 +259,8 @@ module DAV4Rack
       if(token.nil? || token.empty?)
         BadRequest
       else
-        lock = FileResourceLock.find_by_token(token)
-        if(lock.nil? || lock.user_id != @user.id)
+        lock = FileResourceLock.find_by_token(token, root)
+        if lock.nil?
           Forbidden
         elsif(lock.path !~ /^#{Regexp.escape(@path)}.*$/)
           Conflict


### PR DESCRIPTION
Hi,

I'm still trying to implement webdav in my app.

When testing lock and unlock with Office I had the following error: 
`TypeError: can't convert nil into String`  in `file_resource_lock.rb:80:in join` 
after some research I found that `root` is not passed to `#find_by_token` in `FileResource#unlock`  [line:262](https://github.com/chrisroberts/dav4rack/blob/master/lib/dav4rack/resources/file_resource.rb#L262).

Long to find, easy to patch.
But then `#unlock` as an undefined variable `tok`, I supposed it was `struct`.

And finally, its need a little more investigation, but MS Word remove the first and last characters of the token when calling `unlock` then the store never find any token.
I give a look at what is send to the webdav client and the token seem ok. I don't know enough about webdav and have no clue where to look, maybe Word misinterpret the xml sent or just want to be upsetting.
I made a monkey patch to find the good token.

MS Word generate a lot of lock request and fill the token table for the loaded file. Maybe the destroy action should clean all tokens for a given file.
