### PR TITLE
Handle the PROPFIND w/ empty/missing request body case

### DIFF
--- a/lib/dav4rack/controller.rb
+++ b/lib/dav4rack/controller.rb
@@ -186,7 +186,9 @@ module DAV4Rack
       unless(resource.exist?)
         NotFound
       else
-        unless(request_document.xpath("//#{ns}propfind/#{ns}allprop").empty?)
+        # Per RFC 2518 §8.1
+        # An empty PROPFIND request body must be treated as a request for the names and values of all properties.
+        if !request_document.xpath("//#{ns}propfind/#{ns}allprop").empty? or (request.content_length == '0')
           properties = resource.properties
         else
           check = request_document.xpath("//#{ns}propfind")

--- a/lib/dav4rack/controller.rb
+++ b/lib/dav4rack/controller.rb
@@ -188,7 +188,7 @@ module DAV4Rack
       else
         # Per RFC 2518 §8.1
         # An empty PROPFIND request body must be treated as a request for the names and values of all properties.
-        if !request_document.xpath("//#{ns}propfind/#{ns}allprop").empty? or (request.content_length == '0')
+        if !request_document.xpath("//#{ns}propfind/#{ns}allprop").empty? or (request.content_length == '0') or (request.content_length.nil?)
           properties = resource.properties
         else
           check = request_document.xpath("//#{ns}propfind")


### PR DESCRIPTION
Per RFC 2518 §8.1:

_An empty PROPFIND request body must be treated as a request for the names and values of all properties._
