### PR TITLE
Support for PROPFIND with empty request body

### DIFF
--- a/lib/dav4rack/controller.rb
+++ b/lib/dav4rack/controller.rb
@@ -186,7 +186,8 @@ module DAV4Rack
       unless(resource.exist?)
         NotFound
       else
-        unless(request_document.xpath("//#{ns}propfind/#{ns}allprop").empty?)
+        if request_document.children.empty? || !request_document.xpath("//#{ns}propfind/#{ns}allprop").empty?
+#        unless(request_document.xpath("//#{ns}propfind/#{ns}allprop").empty?)
           properties = resource.properties
         else
           check = request_document.xpath("//#{ns}propfind")

--- a/lib/dav4rack/controller.rb
+++ b/lib/dav4rack/controller.rb
@@ -186,8 +186,7 @@ module DAV4Rack
       unless(resource.exist?)
         NotFound
       else
-        if request_document.children.empty? || !request_document.xpath("//#{ns}propfind/#{ns}allprop").empty?
-#        unless(request_document.xpath("//#{ns}propfind/#{ns}allprop").empty?)
+        if(request_document.children.empty? || !request_document.xpath("//#{ns}propfind/#{ns}allprop").empty?)
           properties = resource.properties
         else
           check = request_document.xpath("//#{ns}propfind")

--- a/lib/dav4rack/file_resource_lock.rb
+++ b/lib/dav4rack/file_resource_lock.rb
@@ -43,8 +43,8 @@ module DAV4Rack
         struct = store.transaction(true){
           store[:tokens][token]
         }
-        if(tok)
-          self.class.new(:path => struct[:path], :root => croot)
+        if(token)
+          self.new(:path => struct[:path], :root => croot)
         else
           nil
         end

--- a/lib/dav4rack/resource.rb
+++ b/lib/dav4rack/resource.rb
@@ -86,7 +86,8 @@ module DAV4Rack
       @options = options.dup
       @max_timeout = options[:max_timeout] || 86400
       @default_timeout = options[:default_timeout] || 60
-      @user = @options[:user] || request.ip
+      options[:user] ||= request.ip
+      @user = @options[:user]
       setup if respond_to?(:setup)
       public_methods(false).each do |method|
         next if @skip_alias.include?(method.to_sym) || method[0,4] == 'DAV_' || method[0,5] == '_DAV_'

--- a/lib/dav4rack/resources/file_resource.rb
+++ b/lib/dav4rack/resources/file_resource.rb
@@ -259,8 +259,8 @@ module DAV4Rack
       if(token.nil? || token.empty?)
         BadRequest
       else
-        lock = FileResourceLock.find_by_token(token)
-        if(lock.nil? || lock.user_id != @user.id)
+        lock = FileResourceLock.find_by_token(token, root)
+        if(lock.nil? || lock.user != @user)
           Forbidden
         elsif(lock.path !~ /^#{Regexp.escape(@path)}.*$/)
           Conflict
@@ -350,7 +350,7 @@ module DAV4Rack
     end
 
     def root
-      @options[:root]
+      options[:root]
     end
 
     def file_path


### PR DESCRIPTION
As http://www.ics.uci.edu/~ejw/authoring/protocol/rfc2518.html#METHOD_PROPFIND suggests: "An empty PROPFIND request body MUST be treated as a request for the names and values of all properties."

I saw that Microsoft's Mini-Redirector used to request PROPFIND with empty request body and after applied this patch it worked fine.

I guess we should have some test for that, how can we make it?
